### PR TITLE
Moving backend IP address in .env file

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -9,8 +9,11 @@ import ApolloClient from 'apollo-boost'
 import {Provider} from 'react-redux'
 import store from './store/store'
 import AppNavigator from './navigation/AppNavigator'
+import {BACKEND_SERVER_IP_ADDRESS, GRAPHQL_PORT} from 'react-native-dotenv'
 
-const client = new ApolloClient({uri: 'http://172.17.22.211:1234/graphql'})
+const client = new ApolloClient({
+  uri: `http://${BACKEND_SERVER_IP_ADDRESS}:${GRAPHQL_PORT}/graphql`
+})
 
 export default function App(props) {
   const [isLoadingComplete, setLoadingComplete] = useState(false)

--- a/client/App.js
+++ b/client/App.js
@@ -9,10 +9,13 @@ import ApolloClient from 'apollo-boost'
 import {Provider} from 'react-redux'
 import store from './store/store'
 import AppNavigator from './navigation/AppNavigator'
-import {BACKEND_SERVER_IP_ADDRESS, GRAPHQL_PORT} from 'react-native-dotenv'
+import {
+  BACKEND_SERVER_IP_ADDRESS,
+  EXPRESS_SERVER_PORT
+} from 'react-native-dotenv'
 
 const client = new ApolloClient({
-  uri: `http://${BACKEND_SERVER_IP_ADDRESS}:${GRAPHQL_PORT}/graphql`
+  uri: `http://${BACKEND_SERVER_IP_ADDRESS}:${EXPRESS_SERVER_PORT}/graphql`
 })
 
 export default function App(props) {

--- a/client/babel.config.js
+++ b/client/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = function(api) {
   api.cache(true)
   return {
-    presets: ['babel-preset-expo']
+    presets: [
+      'module:metro-react-native-babel-preset',
+      'module:react-native-dotenv'
+    ]
   }
 }

--- a/client/screens/SnapScreen.js
+++ b/client/screens/SnapScreen.js
@@ -31,6 +31,11 @@ import {useDispatch, useSelector} from 'react-redux'
 import * as Location from 'expo-location'
 import TopNavigation from '../components/TopNavigation'
 
+import {
+  BACKEND_SERVER_IP_ADDRESS,
+  EXPRESS_SERVER_PORT
+} from 'react-native-dotenv'
+
 import Modal, {
   ModalTitle,
   ModalContent,
@@ -99,7 +104,6 @@ export default function SnapScreen(props) {
   }
 
   const onPictureSaved = photo => {
-    const ipAddressOfServer = '172.17.22.211' // <--- PUT YOUR OWN IP HERE
     const uriParts = photo.uri.split('.')
     const fileType = uriParts[uriParts.length - 1]
     let plantCopy
@@ -112,7 +116,10 @@ export default function SnapScreen(props) {
     })
 
     axios
-      .post(`http://${ipAddressOfServer}:1234/image`, formData)
+      .post(
+        `http://${BACKEND_SERVER_IP_ADDRESS}:${EXPRESS_SERVER_PORT}/image`,
+        formData
+      )
       .then(response => {
         console.log('Plant identification response', response.data.commonName)
 
@@ -242,9 +249,12 @@ export default function SnapScreen(props) {
           })
       })
       .catch(err => {
-        // this is the catch for axios.post for autoML
+        console.log(
+          'Tried to send an AJAX request to: ',
+          BACKEND_SERVER_IP_ADDRESS
+        )
         console.log(err)
-        alert('Plant has not been identified')
+        alert('Sending image to server failed')
       })
   }
 
@@ -271,7 +281,7 @@ export default function SnapScreen(props) {
                         size={25}
                         style={styles.leafIcon}
                       />
-                      <Text>        Welcome to Plaze       </Text>
+                      <Text> Welcome to Plaze </Text>
                       <Ionicons name="ios-leaf" color="#6CC7BD" size={25} />
                     </>
                   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4108,6 +4108,21 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-dotenv": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dotenv/-/babel-plugin-dotenv-0.1.1.tgz",
+      "integrity": "sha1-nI+upnp8A0/n6UCZGHqy51c0ALw=",
+      "requires": {
+        "dotenv": "^2.0.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
+          "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk="
+        }
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -11335,6 +11350,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-3.0.1.tgz",
       "integrity": "sha512-vbcYxPZlpF5f39GAEUF8kuGQqCNeD3E6zEdvtOq8oCGZunHXlWlKgAS6dgBKCvsHvXgHuMtpvs39VgOp8DaKig=="
+    },
+    "react-native-dotenv": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-0.2.0.tgz",
+      "integrity": "sha1-MRVRy2o1o9z+3mSL3tVcDj7OV50=",
+      "requires": {
+        "babel-plugin-dotenv": "0.1.1"
+      }
     },
     "react-native-elements": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "node-fetch": "^2.6.0",
     "react": "16.8.3",
     "react-apollo": "^3.1.3",
+    "react-native-dotenv": "^0.2.0",
     "react-native-elements": "^1.2.7",
     "react-native-nav": "^2.0.2",
     "ws": "^7.2.0"

--- a/server/index.js
+++ b/server/index.js
@@ -7,10 +7,10 @@ const {typeDefs, resolvers} = require('./schema')
 const neo4j = require('neo4j-driver').v1
 const {makeAugmentedSchema} = require('neo4j-graphql-js')
 require('dotenv').config()
-const PORT = process.env.PORT
-const GRAPHQL_PORT = process.env.GRAPHQL_PORT
+const EXPRESS_SERVER_PORT = process.env.EXPRESS_SERVER_PORT
+const BACKEND_SERVER_IP_ADDRESS = process.env.BACKEND_SERVER_IP_ADDRESS
+
 const app = express()
-module.exports = app
 
 const graphqlPath = '/graphql'
 
@@ -65,9 +65,10 @@ const createApp = () => {
 }
 
 const startListening = () => {
-  // start listening
-  app.listen(PORT, () =>
-    console.log(`Graphql at http://localhost:${PORT}${graphqlPath}`)
+  app.listen(EXPRESS_SERVER_PORT, () =>
+    console.log(
+      `Express server listening for API calls at http://${BACKEND_SERVER_IP_ADDRESS}:${EXPRESS_SERVER_PORT}`
+    )
   )
 }
 
@@ -76,3 +77,5 @@ async function bootApp() {
   await startListening()
 }
 bootApp()
+
+module.exports = app

--- a/server/seed.js
+++ b/server/seed.js
@@ -1,10 +1,10 @@
 const ApolloClient = require('apollo-boost').default
 const gql = require('graphql-tag')
 const fetch = require('node-fetch')
-const GRAPHQL_PORT = process.env.GRAPHQL_PORT
+const EXPRESS_SERVER_PORT = process.env.EXPRESS_SERVER_PORT
 
 const client = new ApolloClient({
-  uri: `http://localhost:${GRAPHQL_PORT}/graphql`,
+  uri: `http://localhost:${EXPRESS_SERVER_PORT}/graphql`,
   fetch
 })
 client

--- a/server/seed.js
+++ b/server/seed.js
@@ -1,8 +1,10 @@
 const ApolloClient = require('apollo-boost').default
 const gql = require('graphql-tag')
 const fetch = require('node-fetch')
+const GRAPHQL_PORT = process.env.GRAPHQL_PORT
+
 const client = new ApolloClient({
-  uri: 'http://localhost:1234/graphql',
+  uri: `http://localhost:${GRAPHQL_PORT}/graphql`,
   fetch
 })
 client

--- a/server/seed0.js
+++ b/server/seed0.js
@@ -1,10 +1,10 @@
 const ApolloClient = require('apollo-boost').default
 const gql = require('graphql-tag')
 const fetch = require('node-fetch')
-const GRAPHQL_PORT = process.env.GRAPHQL_PORT
+const EXPRESS_SERVER_PORT = process.env.EXPRESS_SERVER_PORT
 
 const client = new ApolloClient({
-  uri: `http://localhost:${GRAPHQL_PORT}/graphql`,
+  uri: `http://localhost:${EXPRESS_SERVER_PORT}/graphql`,
   fetch
 })
 

--- a/server/seed0.js
+++ b/server/seed0.js
@@ -1,9 +1,10 @@
 const ApolloClient = require('apollo-boost').default
 const gql = require('graphql-tag')
 const fetch = require('node-fetch')
+const GRAPHQL_PORT = process.env.GRAPHQL_PORT
 
 const client = new ApolloClient({
-  uri: 'http://localhost:1234/graphql',
+  uri: `http://localhost:${GRAPHQL_PORT}/graphql`,
   fetch
 })
 

--- a/server/seed1.js
+++ b/server/seed1.js
@@ -1,10 +1,10 @@
 const ApolloClient = require('apollo-boost').default
 const gql = require('graphql-tag')
 const fetch = require('node-fetch')
-const GRAPHQL_PORT = process.env.GRAPHQL_PORT
+const EXPRESS_SERVER_PORT = process.env.EXPRESS_SERVER_PORT
 
 const client = new ApolloClient({
-  uri: `http://localhost:${GRAPHQL_PORT}/graphql`,
+  uri: `http://localhost:${EXPRESS_SERVER_PORT}/graphql`,
   fetch
 })
 

--- a/server/seed1.js
+++ b/server/seed1.js
@@ -1,9 +1,10 @@
 const ApolloClient = require('apollo-boost').default
 const gql = require('graphql-tag')
 const fetch = require('node-fetch')
+const GRAPHQL_PORT = process.env.GRAPHQL_PORT
 
 const client = new ApolloClient({
-  uri: 'http://localhost:1234/graphql',
+  uri: `http://localhost:${GRAPHQL_PORT}/graphql`,
   fetch
 })
 


### PR DESCRIPTION
In our prod environment we kept our backend IP address hardcoded, that's a very bad practise ;)
this PR unhardcodes any IP and PORT related stuff

- installed **react-native-dotenv**

Pls note that from now on we have 2 modules to handle .env file
One for backend and one for react-native frontend

Our .env should have;
```
EXPRESS_SERVER_PORT=1234
BACKEND_SERVER_ADDRESS=10.0.0.48
```






